### PR TITLE
chore: remove refs of local directory scanning

### DIFF
--- a/AWS/on-demand/README.md
+++ b/AWS/on-demand/README.md
@@ -71,9 +71,9 @@ A small command-line syntax help utility is available using the `-h` flag.
 
 ```shell
 √ on-demand % piprun quickscan_target.py -h
-usage: Falcon Quick Scan [-h] [-l LOG_LEVEL] [-d CHECK_DELAY] [-b BATCH] -r REGION -t TARGET -k KEY -s SECRET
+usage: quickscan_target.py [-h] [-l LOG_LEVEL] [-d CHECK_DELAY] [-b BATCH] [-w MAX_WORKERS] -r REGION -t TARGET -k KEY -s SECRET
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -l LOG_LEVEL, --log-level LOG_LEVEL
                         Default log level (DEBUG, WARN, INFO, ERROR)
@@ -86,7 +86,7 @@ optional arguments:
   -r REGION, --region REGION
                         Region the target bucket resides in
   -t TARGET, --target TARGET
-                        Target folder or bucket to scan. Bucket must have 's3://' prefix.
+                        S3 bucket to scan. Bucket must have 's3://' prefix.
   -k KEY, --key KEY     CrowdStrike Falcon API KEY
   -s SECRET, --secret SECRET
                         CrowdStrike Falcon API SECRET

--- a/AWS/on-demand/quickscan_target.py
+++ b/AWS/on-demand/quickscan_target.py
@@ -40,8 +40,8 @@ or as a serverless lambda.
 
 REQUIREMENTS:
 - Target must include "s3://" prefix for bucket scanning
-- Requires Google Cloud Storage library and CrowdStrike FalconPy >= v0.8.7
-    python3 -m pip install google-cloud-storage crowdstrike-falconpy
+- Requires AWS SDK and CrowdStrike FalconPy >= v0.8.7
+    python3 -m pip install boto3 crowdstrike-falconpy
 
 CONFIGURATION:
 - Batch size (-b, --batch):
@@ -398,7 +398,7 @@ def parse_command_line():
         "-t",
         "--target",
         dest="target",
-        help="Target folder or bucket to scan. Bucket must have 's3://' prefix.",
+        help="S3 bucket to scan. Bucket must have 's3://' prefix.",
         required=True
     )
     parser.add_argument(

--- a/Azure/on-demand/README.md
+++ b/Azure/on-demand/README.md
@@ -94,7 +94,7 @@ A small command-line syntax help utility is available using the `-h` flag.
 
 ```shell
 python3 quickscan_target.py -h
-usage: Falcon Quick Scan [-h] [-l LOG_LEVEL] [-d CHECK_DELAY] [-b BATCH] -t TARGET -k KEY -s SECRET
+usage: quickscan_target.py [-h] [-l LOG_LEVEL] [-d CHECK_DELAY] [-b BATCH] [-w MAX_WORKERS] -t TARGET -k KEY -s SECRET
 
 options:
   -h, --help            show this help message and exit
@@ -103,11 +103,11 @@ options:
   -d CHECK_DELAY, --check-delay CHECK_DELAY
                         Delay between checks for scan results
   -b BATCH, --batch BATCH
-                        The number of files to include in a volume to scan.
+                        The number of files to include in a volume to scan (default: 1000).
   -w MAX_WORKERS, --workers MAX_WORKERS
                         Maximum number of worker threads to use for scanning (default: 10).
   -t TARGET, --target TARGET
-                        Target folder or container to scan. Value must start with 'https://' and have '.blob.core.windows.net' url suffix.
+                        Value must start with 'https://' and have '.blob.core.windows.net' url suffix.
   -k KEY, --key KEY     CrowdStrike Falcon API KEY
   -s SECRET, --secret SECRET
                         CrowdStrike Falcon API SECRET

--- a/Azure/on-demand/quickscan_target.py
+++ b/Azure/on-demand/quickscan_target.py
@@ -301,7 +301,7 @@ class QuickScanApp:
 
 def parse_command_line():
     """Parse any inbound command line arguments and set defaults."""
-    parser = argparse.ArgumentParser("Falcon QuickScan Pro Pro")
+    parser = argparse.ArgumentParser("quickscan_target.py")
     parser.add_argument(
         "-l",
         "--log-level",
@@ -320,7 +320,7 @@ def parse_command_line():
         "-b",
         "--batch",
         dest="batch",
-        help="The number of files to include in a volume to scan.",
+        help="The number of files to include in a volume to scan (default: 1000).",
         required=False,
     )
     parser.add_argument(
@@ -334,7 +334,7 @@ def parse_command_line():
         "-t",
         "--target",
         dest="target",
-        help="Target folder or container to scan. Value must start with 'https://' and have '.blob.core.windows.net' url suffix.",
+        help="Value must start with 'https://' and have '.blob.core.windows.net' url suffix.",
         required=True,
     )
     parser.add_argument(

--- a/GCP/on-demand/README.md
+++ b/GCP/on-demand/README.md
@@ -91,7 +91,7 @@ options:
   -p PROJECT_ID, --project PROJECT_ID
                         Project ID the target bucket resides in
   -t TARGET, --target TARGET
-                        Target folder or bucket to scan. Bucket must have 'gs://' prefix.
+                        Cloud Storage bucket to scan. Bucket must have 'gs://' prefix.
   -k KEY, --key KEY     CrowdStrike Falcon API KEY
   -s SECRET, --secret SECRET
                         CrowdStrike Falcon API SECRET

--- a/GCP/on-demand/quickscan_target.py
+++ b/GCP/on-demand/quickscan_target.py
@@ -392,7 +392,7 @@ def parse_command_line():
         "-t",
         "--target",
         dest="target",
-        help="Target folder or bucket to scan. Bucket must have 'gs://' prefix.",
+        help="Cloud Storage bucket to scan. Bucket must have 'gs://' prefix.",
         required=True,
     )
     parser.add_argument(


### PR DESCRIPTION
Closes #7

Removes refs of local directory for -t in the docstrings/help menus. Updates documentation and also ensures consistent python3 help menus amongst cloud providers.