### PR TITLE
feat: add user-agent strings to identify API requests

### DIFF
--- a/AWS/lambda/lambda_function.py
+++ b/AWS/lambda/lambda_function.py
@@ -103,7 +103,11 @@ def lambda_handler(event, _):
             falcon_client_id = secrets_dict["FalconClientId"]
             falcon_secret = secrets_dict["FalconSecret"]
             # Connect to the QuickScan Pro API
-            uber = APIHarnessV2(client_id=falcon_client_id, client_secret=falcon_secret)
+            uber = APIHarnessV2(
+                client_id=falcon_client_id,
+                client_secret=falcon_secret,
+                user_agent="cloud-storage-protection/aws/lambda",
+            )
             scanner = QuickScanPro(auth_object=uber)
         if upload_file_size < MAX_FILE_SIZE:
             # Get the file from S3

--- a/AWS/on-demand/quickscan_target.py
+++ b/AWS/on-demand/quickscan_target.py
@@ -174,6 +174,7 @@ class QuickScanApp:
         return APIHarnessV2(
             client_id=self.config.falcon_client_id,
             client_secret=self.config.falcon_client_secret,
+            user_agent="cloud-storage-protection/aws/on-demand",
         )
 
     def run(self):

--- a/Azure/function-app/function_app.py
+++ b/Azure/function-app/function_app.py
@@ -40,7 +40,12 @@ except KeyError as exc:
     raise SystemExit("FALCON_CLIENT_SECRET environment variable not set") from exc
 
 # Authenticate to the CrowdStrike Falcon API
-uber = APIHarnessV2(client_id=client_id, client_secret=client_secret, base_url=BASE_URL)
+uber = APIHarnessV2(
+    client_id=client_id,
+    client_secret=client_secret,
+    base_url=BASE_URL,
+    user_agent="cloud-storage-protection/azure/function-app",
+)
 
 # Connect to the QuickScan Pro API
 Scanner = QuickScanPro(auth_object=uber)

--- a/Azure/on-demand/quickscan_target.py
+++ b/Azure/on-demand/quickscan_target.py
@@ -106,6 +106,7 @@ class QuickScanApp:
         return APIHarnessV2(
             client_id=self.config.falcon_client_id,
             client_secret=self.config.falcon_client_secret,
+            user_agent="cloud-storage-protection/azure/on-demand",
         )
 
     def run(self):

--- a/GCP/cloud-function/main.py
+++ b/GCP/cloud-function/main.py
@@ -70,7 +70,12 @@ except KeyError as exc:
     raise SystemExit("FALCON_CLIENT_SECRET environment variable not set") from exc
 
 # Authenticate to the CrowdStrike Falcon API
-uber = APIHarnessV2(client_id=client_id, client_secret=client_secret, base_url=BASE_URL)
+uber = APIHarnessV2(
+    client_id=client_id,
+    client_secret=client_secret,
+    base_url=BASE_URL,
+    user_agent="cloud-storage-protection/gcp/cloud-function",
+)
 
 # Connect to the QuickScan Pro API
 Scanner = QuickScanPro(auth_object=uber)

--- a/GCP/on-demand/quickscan_target.py
+++ b/GCP/on-demand/quickscan_target.py
@@ -170,6 +170,7 @@ class QuickScanApp:
         return APIHarnessV2(
             client_id=self.config.falcon_client_id,
             client_secret=self.config.falcon_client_secret,
+            user_agent="cloud-storage-protection/gcp/on-demand",
         )
 
     def run(self):


### PR DESCRIPTION
## Summary
- Adds `user_agent` parameter to all `APIHarnessV2` initializations across all cloud providers
- User-agent format: `cloud-storage-protection/{cloud}/{component}`
- Enables tracking which specific component is making CrowdStrike API requests

## Components Updated
| Cloud | Component | User-Agent String |
|-------|-----------|-------------------|
| AWS | Lambda | `cloud-storage-protection/aws/lambda` |
| AWS | On-Demand Scanner | `cloud-storage-protection/aws/on-demand` |
| Azure | Function App | `cloud-storage-protection/azure/function-app` |
| Azure | On-Demand Scanner | `cloud-storage-protection/azure/on-demand` |
| GCP | Cloud Function | `cloud-storage-protection/gcp/cloud-function` |
| GCP | On-Demand Scanner | `cloud-storage-protection/gcp/on-demand` |

Closes #22